### PR TITLE
Some minor fixes + patch for ESP32 + modem connection

### DIFF
--- a/Minitel1B_Hard.cpp
+++ b/Minitel1B_Hard.cpp
@@ -747,6 +747,17 @@ byte Minitel::statusAiguillage(byte module) {  // Voir p. 136
 }
 /*--------------------------------------------------------------------*/
 
+byte Minitel::connexion(boolean commande) {  // Voir p.139
+  // commande peut prendre comme valeur :
+  // true, false
+  // Commande
+  writeBytesPRO(1);  // 0x1B 0x3A
+  writeByte(commande ? CONNEXION : DECONNEXION);  // 0x68 ou 0x67
+  // Acquittement
+  return workingModem();  // Renvoie un octet
+}
+/*--------------------------------------------------------------------*/
+
 byte Minitel::reset() {  // Voir p.145
   // Commande
   writeBytesPRO(1);  // 0x1B 0x39
@@ -899,6 +910,22 @@ byte Minitel::workingAiguillage(byte module) {  // Voir p.136
   }
   while (!mySerial.available()>0);  // Indispensable
   return readByte(); // Octet de statut associé à un module
+}
+/*--------------------------------------------------------------------*/
+
+byte Minitel::workingModem() {  // Voir p.126
+  // On récupère uniquement la séquence immédiate 0x1359
+  // en cas de connexion confirmé, la séquence 0x1356 s'ajoutera - non traité ici
+  // en cas de timeout (environ 40sec), la séquence 0x1359 s'ajoutera - non traité ici
+  while (!mySerial);  // On attend que le port soit sur écoute.
+  unsigned int trame = 0;  // 16 bits = 2 octets
+  while (trame >> 8 != 0x13) {
+    if (mySerial.available() > 0) {
+      trame = (trame << 8) + readByte();
+      //Serial.println(trame, HEX);
+    }
+  }
+  return (byte) trame;
 }
 /*--------------------------------------------------------------------*/
 

--- a/Minitel1B_Hard.cpp
+++ b/Minitel1B_Hard.cpp
@@ -92,11 +92,13 @@ int Minitel::changeSpeed(int bauds) {  // Voir p.141
   writeBytesPRO(2);  // 0x1B 0x3A
   writeByte(PROG);   // 0x6B
   switch (bauds) {
-    case  300 : writeByte(0b1010010); mySerial.begin( 300); break;  // 0x52
-    case 1200 : writeByte(0b1100100); mySerial.begin(1200); break;  // 0x64
-    case 4800 : writeByte(0b1110110); mySerial.begin(4800); break;  // 0x76
-    case 9600 : writeByte(0b1111111); mySerial.begin(9600); break;  // 0x7F (pour le Minitel 2 seulement)
+    case  300 : writeByte(0b1010010); break;  // 0x52
+    case 1200 : writeByte(0b1100100); break;  // 0x64
+    case 4800 : writeByte(0b1110110); break;  // 0x76
+    case 9600 : writeByte(0b1111111); break;  // 0x7F (pour le Minitel 2 seulement)
   }
+  mySerial.end();
+  mySerial.begin(bauds);
   // Acquittement
   return workingSpeed();  // En bauds (voir section Private ci-dessous)
 }

--- a/Minitel1B_Hard.cpp
+++ b/Minitel1B_Hard.cpp
@@ -97,6 +97,9 @@ int Minitel::changeSpeed(int bauds) {  // Voir p.141
     case 4800 : writeByte(0b1110110); break;  // 0x76
     case 9600 : writeByte(0b1111111); break;  // 0x7F (pour le Minitel 2 seulement)
   }
+  #if defined(ESP32) || defined(ARDUINO_ARCH_ESP32)
+  mySerial.flush(false); // Patch pour Arduino-ESP32 core v1.0.6 https://github.com/espressif/arduino-esp32
+  #endif
   mySerial.end();
   mySerial.begin(bauds);
   // Acquittement

--- a/Minitel1B_Hard.cpp
+++ b/Minitel1B_Hard.cpp
@@ -710,10 +710,10 @@ byte Minitel::standardKeyboard() {
 }
 /*--------------------------------------------------------------------*/
 
-byte Minitel::echo(boolean commande) {  // Voir p.81 et p.156
+byte Minitel::echo(boolean commande) {  // Voir p.81, p.135 et p.156
   // commande peut prendre comme valeur :
   // true, false
-  return aiguillage(commande, CODE_EMISSION_MODEM, CODE_RECEPTION_ECRAN);
+  return aiguillage(commande, CODE_EMISSION_CLAVIER, CODE_RECEPTION_MODEM);
 }
 /*--------------------------------------------------------------------*/
 

--- a/Minitel1B_Hard.cpp
+++ b/Minitel1B_Hard.cpp
@@ -843,14 +843,19 @@ int Minitel::workingSpeed() {
 
 byte Minitel::workingStandard(unsigned long sequence) {
   while (!mySerial);  // On attend que le port soit sur écoute.
+  unsigned long time = millis();
+  unsigned long duree = 0;
   unsigned long trame = 0;  // 32 bits = 4 octets  
-  while (trame != sequence) {
+  // On se donne 100ms pour recevoir l'acquittement
+  // Sinon, on peut supposer que le mode demandé était déjà actif
+  while ((trame != sequence) && (duree < 100)) {
     if (mySerial.available() > 0) {
       trame = (trame << 8) + readByte();
       //Serial.println(trame, HEX);
     }
+    duree = millis() - time;
   }
-  return 0;
+  return (trame == sequence)? 1 : 0;
 }
 /*--------------------------------------------------------------------*/
 

--- a/Minitel1B_Hard.h
+++ b/Minitel1B_Hard.h
@@ -211,6 +211,10 @@
 #define TO                         0x62
 #define FROM                       0x63
 
+// 7 Commandes relatives au modem
+#define CONNEXION               0x68
+#define DECONNEXION             0x67
+
 // 8 Commandes relatives à la prise (voir p.141)
 #define PROG                       0x6B
 #define STATUS_VITESSE             0x74
@@ -351,6 +355,7 @@ public:
   // Protocole
   byte aiguillage(boolean commande, byte emetteur, byte recepteur);
   byte statusAiguillage(byte module);
+  byte connexion(boolean commande);
   byte reset();
   
 private: 
@@ -368,6 +373,7 @@ private:
   byte workingMode();
   byte workingKeyboard();
   byte workingAiguillage(byte module);
+  byte workingModem();
   
   unsigned long getCursorXY();
 };


### PR DESCRIPTION
_changeSpeed_:
  - ajout de serial.end avant de relancer la liaison (testé sur Arduino, nécessaire pour avoir un acquittement correct)
  - ajout d'un patch pour l'ESP32 (testé pour arduino-ESP32 core v1.0.6)
  
_echo_:
  - agit au départ de la boucle echo (clavier > modem), tout comme la commande FNCT+T E en local (voir p.135). Cela permet de rétablir l'écho via la commande clavier si besoin.
  
_connexion_:
  - fonction de connexion / deconnexion du modem (équivalent de la touche CONNEXION / FIN)
  