### PR TITLE
unicode correction for beta character

### DIFF
--- a/Minitel1B_Hard.cpp
+++ b/Minitel1B_Hard.cpp
@@ -445,7 +445,7 @@ void Minitel::print(String chaine) {
         case 0x60: code = 0; break; // ` non visualisable seul
       }
     }
-    else if (code == 0xC2 || code == 0xC3 || code == 0xC5) {
+    else if (code == 0xC2 || code == 0xC3 || code == 0xC5 || code == 0xCE) {
       // Caractères sur 2 octets
       code = (code << 8) + (byte) chaine.charAt(i++);
       switch (code) {                        // Voir p.90 pour VGP5 ou VGP2
@@ -473,7 +473,6 @@ void Minitel::print(String chaine) {
         case 0xC399: code = 0x0F55; break;   // Ù (Aucune lettre accentuée majuscule n'est disponible - voir p.90)
         case 0xC39B: code = 0x0F55; break;   // Û (Aucune lettre accentuée majuscule n'est disponible - voir p.90)
         case 0xC39C: code = 0x0F55; break;   // Ü (Aucune lettre accentuée majuscule n'est disponible - voir p.90)
-        case 0xC39F: code = 0x197B; break;   // ß (VGP5 seulement)
         case 0xC3A0: code = 0x194161; break; // à (VGP5 et VGP2)
         case 0xC3A2: code = 0x194361; break; // â (VGP5 et VGP2)
         case 0xC3A4: code = 0x194861; break; // ä (VGP5 seulement)
@@ -492,6 +491,7 @@ void Minitel::print(String chaine) {
         case 0xC3BC: code = 0x194875; break; // ü (VGP5 seulement)
         case 0xC592: code = 0x196A; break;   // Œ (VGP5 et VGP2)
         case 0xC593: code = 0x197A; break;   // œ (VGP5 et VGP2)
+        case 0xCEB2: code = 0x197B; break;   // β (VGP5 seulement)
         default: code = 0; // supposé non-visualisable
       }
     }
@@ -761,7 +761,7 @@ unsigned long Minitel::getKeyCode(bool unicode) {
           case 0x1938 : code = 0xF7; break;    // Division
           case 0x196A : code = 0x152; break;   // Ligature OE
           case 0x197A : code = 0x153; break;   // Ligature oe
-          case 0x197B : code = 0xDF; break;    // Bêta
+          case 0x197B : code = 0x3B2; break;   // Bêta
         }
       }
     }
@@ -965,7 +965,6 @@ boolean Minitel::isVisualisable(unsigned long code) {
     case 0x00C8: return true; // È (VGP2)
     case 0x00C9: return true; // É (VGP2)
     */
-    case 0x00DF: return true; // ß (VGP5 seulement, pas VGP2 - voir p.90)
     case 0x00E0: return true; // à
     case 0x00E2: return true; // â
     case 0x00E4: return true; // ä (VGP5 seulement, pas VGP2 - voir p.90)
@@ -984,6 +983,7 @@ boolean Minitel::isVisualisable(unsigned long code) {
     case 0x00FC: return true; // ü (VGP5 seulement, pas VGP2 - voir p.90)
     case 0x0152: return true; // Œ
     case 0x0153: return true; // œ
+    case 0x03B2: return true; // β (VGP5 seulement, pas VGP2 - voir p.90)
     case 0x2014: return true; // — Ctrl 5 au clavier
     case 0x2190: return true; // ← Ctrl 8 au clavier
     case 0x2191: return true; // ↑

--- a/Minitel1B_Hard.h
+++ b/Minitel1B_Hard.h
@@ -214,6 +214,10 @@
 #define TO                         0x62
 #define FROM                       0x63
 
+// 6 Demandes d'identification et de position curseur (voir p.139)
+// 6.1 Demande d'identification du Minitel (voir p.139)
+#define ENQROM                     0x7B
+
 // 7 Commandes relatives au modem (voir p.139)
 #define CONNEXION                  0x68
 #define DECONNEXION                0x67
@@ -269,6 +273,9 @@ public:
   void writeWord(word w);
   void write(unsigned long code);
   byte readByte();
+  
+  // Identification du type de minitel
+  unsigned long identifyDevice();
   
   // Vitesse de la liaison série
   // A la mise sous tension du Minitel, la vitesse des échanges entre
@@ -374,6 +381,7 @@ private:
   
   // Protocole
   void writeBytesPRO(int n);  // PRO1, PRO2 ou PRO3
+  unsigned long identificationBytes();
   int workingSpeed();
   byte workingStandard(unsigned long sequence);
   byte workingMode();


### PR DESCRIPTION
Description :
Beta (β) was wrongly attributed to german sharp s character (ß). 
This is corrected by modifying letter code in functions : print, getKeyCode & isVisualisable
