### PR TITLE
correction bug dans la fonction correction

### DIFF
--- a/examples/TestCaracteresSpeciaux/TestCaracteresSpeciaux.ino
+++ b/examples/TestCaracteresSpeciaux/TestCaracteresSpeciaux.ino
@@ -97,7 +97,11 @@ void correction(int nbLignes) {
     minitel.print(VIDE);
     minitel.attributs(CARACTERE_BLANC);
     minitel.moveCursorLeft(1);
-    texte = texte.substring(0,texte.length()-1);
+    unsigned int index = texte.length()-1;
+    if (texte.charAt(index) >> 7) { // caractère spécial
+      while ((texte.charAt(index) >> 6) != 0b11) index--;
+    }
+    texte.remove(index);
     nbCaracteres--;
   }
 }


### PR DESCRIPTION
Lors d'un appui sur la touche CORRECTION, le dernier caractère du texte est sensé être supprimé 
Or pour supprimer un caractère spécial dans un objet String, il faut retirer plusieurs octets ! 
Cela se voit par l'apparition d'un caractère ⸮ dans le moniteur série


Je commence par un test pour détecter s'il s'agit d'un caractère spécial 
Le cas échéant je cherche l'index correspondant à son premier octet 
Puis je supprime l'ensemble