### PR TITLE
SERIAL_7E1 & Correctif pour ESP32 et Arduino Leonardo

### DIFF
--- a/Minitel1B_Hard.cpp
+++ b/Minitel1B_Hard.cpp
@@ -43,6 +43,15 @@ Minitel::Minitel(HardwareSerial& serial) : mySerial(serial) {
 }
 /*--------------------------------------------------------------------*/
 
+#if defined(ESP32) || defined(ARDUINO_ARCH_ESP32)
+Minitel::Minitel(HardwareSerial& serial, int8_t rxPin, int8_t txPin) : mySerial(serial) {
+  // A la mise sous tension du Minitel, la vitesse des échanges entre
+  // le Minitel et le périphérique est de 1200 bauds par défaut.
+  mySerial.begin(1200, SERIAL_7E1, rxPin, txPin);
+}
+#endif
+/*--------------------------------------------------------------------*/
+
 void Minitel::writeByte(byte b) {
   // Cette fonction servait à ajouter le bit de parité pour la communication avec le minitel
   // Cela se fait désormais avec l'option SERIAL_7E1 de la fonction begin.

--- a/Minitel1B_Hard.cpp
+++ b/Minitel1B_Hard.cpp
@@ -165,7 +165,7 @@ int Minitel::changeSpeed(int bauds) {  // Voir p.141
     case 9600 : writeByte(0b1111111); break;  // 0x7F (pour le Minitel 2 seulement)
   }
   #if defined(ESP32) || defined(ARDUINO_ARCH_ESP32)
-  mySerial.flush(false); // Patch pour Arduino-ESP32 core v1.0.6 https://github.com/espressif/arduino-esp32
+  mySerial.flush(false); // Patch pour Arduino-ESP32 (still needed for v2.0.8)
   #else
   mySerial.end();
   #endif

--- a/Minitel1B_Hard.cpp
+++ b/Minitel1B_Hard.cpp
@@ -39,11 +39,15 @@
 Minitel::Minitel(HardwareSerial& serial) : mySerial(serial) {
   // A la mise sous tension du Minitel, la vitesse des échanges entre
   // le Minitel et le périphérique est de 1200 bauds par défaut.
-  mySerial.begin(1200);
+  mySerial.begin(1200, SERIAL_7E1);
 }
 /*--------------------------------------------------------------------*/
 
 void Minitel::writeByte(byte b) {
+  // Cette fonction servait à ajouter le bit de parité pour la communication avec le minitel
+  // Cela se fait désormais avec l'option SERIAL_7E1 de la fonction begin.
+   
+  /*
   // Le bit de parité est mis à 0 si la somme des autres bits est paire
   // et à 1 si elle est impaire.
   boolean parite = 0;
@@ -58,6 +62,8 @@ void Minitel::writeByte(byte b) {
   else {
     bitWrite(b,7,0);  // Ecriture du bit de parité
   }
+  */
+   
   mySerial.write(b);  // Envoi de l'octet sur le port série
 }
 /*--------------------------------------------------------------------*/
@@ -84,7 +90,12 @@ void Minitel::writeCode(unsigned long code) {
 /*--------------------------------------------------------------------*/
 
 byte Minitel::readByte() {
+  // Cette fonction servait à ajouter le bit de parité pour la communication avec le minitel
+  // Cela se fait désormais avec l'option SERIAL_7E1 de la fonction begin.
+   
   byte b = mySerial.read();
+  
+  /*
   // Le bit de parité est à 0 si la somme des autres bits est paire
   // et à 1 si elle est impaire.
   boolean parite = 0;
@@ -102,6 +113,10 @@ byte Minitel::readByte() {
   else {
     return 0xFF;  // Pour indiquer une erreur de parité.
   }
+  */
+  
+  return b;
+  
 }
 /*--------------------------------------------------------------------*/
 
@@ -151,9 +166,10 @@ int Minitel::changeSpeed(int bauds) {  // Voir p.141
   }
   #if defined(ESP32) || defined(ARDUINO_ARCH_ESP32)
   mySerial.flush(false); // Patch pour Arduino-ESP32 core v1.0.6 https://github.com/espressif/arduino-esp32
-  #endif
+  #else
   mySerial.end();
-  mySerial.begin(bauds);
+  #endif
+  mySerial.begin(bauds, SERIAL_7E1);
   // Acquittement
   return workingSpeed();  // En bauds (voir section Private ci-dessous)
 }
@@ -169,11 +185,11 @@ int Minitel::currentSpeed() {  // Voir p.141
 /*--------------------------------------------------------------------*/
 
 int Minitel::searchSpeed() {
-  const int SPEED[4] = { 1200, 4800, 300, 9600 };  // 9600 bauds pour le Minitel 2 seulement
+  const int _SPEED[4] = { 1200, 4800, 300, 9600 };  // 9600 bauds pour le Minitel 2 seulement
   int i = 0;
   int speed;
   do {
-    mySerial.begin(SPEED[i]);
+    mySerial.begin(_SPEED[i], SERIAL_7E1);
     if (i++ > 3) { i = 0; }
     speed = currentSpeed();
   } while (speed < 0);

--- a/Minitel1B_Hard.cpp
+++ b/Minitel1B_Hard.cpp
@@ -197,7 +197,7 @@ int Minitel::currentSpeed() {  // Voir p.141
 int Minitel::searchSpeed() {
   const int _SPEED[4] = { 1200, 4800, 300, 9600 };  // 9600 bauds pour le Minitel 2 seulement
   int i = 0;
-	int speed;
+  int speed;
   do {
     mySerial.begin(_SPEED[i], SERIAL_7E1);
     if (i++ > 3) { i = 0; }

--- a/Minitel1B_Hard.cpp
+++ b/Minitel1B_Hard.cpp
@@ -199,7 +199,7 @@ int Minitel::searchSpeed() {
   int i = 0;
   int speed;
   do {
-    mySerial.begin(_SPEED[i], SERIAL_7E1);
+  const int _SPEED[4] = { 1200, 4800, 300, 9600 };  // 9600 bauds pour le Minitel 2 seulement
     if (i++ > 3) { i = 0; }
     speed = currentSpeed();
   } while (speed < 0);
@@ -580,20 +580,13 @@ void Minitel::print(String chaine) {
 
 void Minitel::println(String chaine) {
   print(chaine);
-  if (currentSize == DOUBLE_HAUTEUR || currentSize == DOUBLE_GRANDEUR) {
-    moveCursorReturn(2);
-  }
-  else {
-    moveCursorReturn(1);
-  }
+  println();
 }
 /*--------------------------------------------------------------------*/
 
 void Minitel::println() {
+  moveCursorReturn(1);
   if (currentSize == DOUBLE_HAUTEUR || currentSize == DOUBLE_GRANDEUR) {
-    moveCursorReturn(2);
-  }
-  else {
     moveCursorReturn(1);
   }
 }
@@ -719,7 +712,7 @@ int Minitel::getNbBytes(unsigned long code) {
 /*--------------------------------------------------------------------*/
 
 void Minitel::graphic(byte b, int x, int y) {
-  moveCursorXY(x,y);
+  newXY(x,y);
   graphic(b);
 }
 /*--------------------------------------------------------------------*/
@@ -763,7 +756,7 @@ void Minitel::rect(int x1, int y1, int x2, int y2) {
 
 void Minitel::hLine(int x1, int y, int x2, int position) {
   textMode();
-  moveCursorXY(x1,y);
+  newXY(x1,y);
   switch (position) {
     case TOP    : writeByte(0x7E); break;
     case CENTER : writeByte(0x60); break;
@@ -776,8 +769,8 @@ void Minitel::hLine(int x1, int y, int x2, int position) {
 void Minitel::vLine(int x, int y1, int y2, int position, int sens) {
   textMode();
   switch (sens) {
-    case DOWN : moveCursorXY(x,y1); break;
-    case UP   : moveCursorXY(x,y2); break;
+    case DOWN : newXY(x,y1); break;
+    case UP   : newXY(x,y2); break;
   }
   for (int i=0; i<y2-y1; i++) {
     switch (position) {

--- a/Minitel1B_Hard.cpp
+++ b/Minitel1B_Hard.cpp
@@ -195,10 +195,11 @@ int Minitel::currentSpeed() {  // Voir p.141
 /*--------------------------------------------------------------------*/
 
 int Minitel::searchSpeed() {
-  mySerial.begin(_SPEED[i], SERIAL_7E1);  int i = 0;
-  int speed;
-  do {
   const int _SPEED[4] = { 1200, 4800, 300, 9600 };  // 9600 bauds pour le Minitel 2 seulement
+  int i = 0;
+	int speed;
+  do {
+    mySerial.begin(_SPEED[i], SERIAL_7E1);
     if (i++ > 3) { i = 0; }
     speed = currentSpeed();
   } while (speed < 0);

--- a/Minitel1B_Hard.cpp
+++ b/Minitel1B_Hard.cpp
@@ -195,8 +195,7 @@ int Minitel::currentSpeed() {  // Voir p.141
 /*--------------------------------------------------------------------*/
 
 int Minitel::searchSpeed() {
-  const int _SPEED[4] = { 1200, 4800, 300, 9600 };  // 9600 bauds pour le Minitel 2 seulement
-  int i = 0;
+  mySerial.begin(_SPEED[i], SERIAL_7E1);  int i = 0;
   int speed;
   do {
   const int _SPEED[4] = { 1200, 4800, 300, 9600 };  // 9600 bauds pour le Minitel 2 seulement

--- a/Minitel1B_Hard.cpp
+++ b/Minitel1B_Hard.cpp
@@ -200,7 +200,7 @@ int Minitel::searchSpeed() {
   int speed;
   do {
     mySerial.begin(_SPEED[i], SERIAL_7E1);
-    if (i++ > 3) { i = 0; }
+    if (++i > 3) { i = 0; }
     speed = currentSpeed();
   } while (speed < 0);
   return speed;  // En bauds

--- a/Minitel1B_Hard.cpp
+++ b/Minitel1B_Hard.cpp
@@ -175,10 +175,11 @@ int Minitel::changeSpeed(int bauds) {  // Voir p.141
   }
   #if defined(ESP32) || defined(ARDUINO_ARCH_ESP32)
   mySerial.flush(false); // Patch pour Arduino-ESP32 (still needed for v2.0.8)
+  mySerial.updateBaudRate(bauds);
   #else
   mySerial.end();
-  #endif
   mySerial.begin(bauds, SERIAL_7E1);
+  #endif
   // Acquittement
   return workingSpeed();  // En bauds (voir section Private ci-dessous)
 }

--- a/Minitel1B_Hard.cpp
+++ b/Minitel1B_Hard.cpp
@@ -1120,11 +1120,13 @@ void Minitel::writeBytesPRO(int n) {  // Voir p.134
 
 unsigned long Minitel::identificationBytes() {  // Voir p.138
   while (!mySerial);  // On attend que le port soit sur écoute.
+  unsigned long time = millis();
   unsigned long trame = 0;  // 32 bits = 4 octets
   while (trame >> 24 != 0x01) {  // La trame doit débuter par SOH (0x01)
     if (mySerial.available() > 0) {
       trame = (trame << 8) + readByte();
     }
+    if (millis() - time > 1000) return 0; // On se donne 1000ms pour obtenir la réponse
   }
   while (!mySerial.available()>0); // Indispensable
   if (readByte() != 0x04) return 0;  // La trame doit se terminer par EOT (0x04)

--- a/Minitel1B_Hard.h
+++ b/Minitel1B_Hard.h
@@ -268,6 +268,10 @@ class Minitel
 public:
   Minitel(HardwareSerial& serial);
   
+  #if defined(ESP32) || defined(ARDUINO_ARCH_ESP32)
+  Minitel(HardwareSerial& serial, int8_t rxPin, int8_t txPin);
+  #endif
+  
   // Ecrire un octet, un mot ou un code de 4 octets maximum / Lire un octet
   void writeByte(byte b);
   void writeWord(word w);


### PR DESCRIPTION
Voir les descriptions des commits pour plus de détails

Cette version a été testé avec esp32_wroom32e / esp32_wrover / arduino_leonardo(atmega32u4)

Resumé des modifs :

- Utilisation de la config SERIAL_7E1 de hardwareSerial (calcul de parité natif des noyaux arduino et esp32)
- On ne ferme pas la liaison série au moment de changer la vitesse pour l'esp32 car cela parasite l'acquittement dans certains cas. La fermeture reste nécessaire pour les arduinos (ajout macro #else)
- Renommage de la variable SPEED en _SPEED (conflit avec le noyau)
- Ajout d'un constructeur pour ESP32 permettant la relocalisation des broches à utiliser pour le port Série. Les paramètres rxPin et txPin sont relatifs à l'esp32 : rxPin va au tx du minitel et txPin va au rx du minitel
