### PR TITLE
Switch from moveCursorXY to newXY for more compatibility (e.g. Minitel1)

### DIFF
--- a/Minitel1B_Hard.cpp
+++ b/Minitel1B_Hard.cpp
@@ -693,7 +693,7 @@ int Minitel::getNbBytes(unsigned long code) {
 /*--------------------------------------------------------------------*/
 
 void Minitel::graphic(byte b, int x, int y) {
-  moveCursorXY(x,y);
+  newXY(x,y);
   graphic(b);
 }
 /*--------------------------------------------------------------------*/
@@ -737,7 +737,7 @@ void Minitel::rect(int x1, int y1, int x2, int y2) {
 
 void Minitel::hLine(int x1, int y, int x2, int position) {
   textMode();
-  moveCursorXY(x1,y);
+  newXY(x1,y);
   switch (position) {
     case TOP    : writeByte(0x7E); break;
     case CENTER : writeByte(0x60); break;
@@ -750,8 +750,8 @@ void Minitel::hLine(int x1, int y, int x2, int position) {
 void Minitel::vLine(int x, int y1, int y2, int position, int sens) {
   textMode();
   switch (sens) {
-    case DOWN : moveCursorXY(x,y1); break;
-    case UP   : moveCursorXY(x,y2); break;
+    case DOWN : newXY(x,y1); break;
+    case UP   : newXY(x,y2); break;
   }
   for (int i=0; i<y2-y1; i++) {
     switch (position) {

--- a/Minitel1B_Hard.cpp
+++ b/Minitel1B_Hard.cpp
@@ -554,20 +554,13 @@ void Minitel::print(String chaine) {
 
 void Minitel::println(String chaine) {
   print(chaine);
-  if (currentSize == DOUBLE_HAUTEUR || currentSize == DOUBLE_GRANDEUR) {
-    moveCursorReturn(2);
-  }
-  else {
-    moveCursorReturn(1);
-  }
+  println();
 }
 /*--------------------------------------------------------------------*/
 
 void Minitel::println() {
+	moveCursorReturn(1);
   if (currentSize == DOUBLE_HAUTEUR || currentSize == DOUBLE_GRANDEUR) {
-    moveCursorReturn(2);
-  }
-  else {
     moveCursorReturn(1);
   }
 }

--- a/Minitel1B_Hard.cpp
+++ b/Minitel1B_Hard.cpp
@@ -559,7 +559,7 @@ void Minitel::println(String chaine) {
 /*--------------------------------------------------------------------*/
 
 void Minitel::println() {
-	moveCursorReturn(1);
+  moveCursorReturn(1);
   if (currentSize == DOUBLE_HAUTEUR || currentSize == DOUBLE_GRANDEUR) {
     moveCursorReturn(1);
   }


### PR DESCRIPTION
Using newXY there is the same result of moveCursorXY, but it's compatible also with Minitel1 (not 1B) terminals
